### PR TITLE
Download code from external sources #7

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,10 +63,11 @@
 				reveal: {
 					history: true,
 					dependencies: [
+						{ src: 'js/remote-code.js' },
 						{ src: 'plugin/markdown/marked.js' },
 						{ src: 'plugin/markdown/markdown.js' },
 						{ src: 'plugin/notes/notes.js', async: true },
-						{ src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
+						{ src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); fetchAllCode(); } }
 					]
 				}
 			});

--- a/docs/js/remote-code.js
+++ b/docs/js/remote-code.js
@@ -1,0 +1,24 @@
+fetchAllCode = function(){ 
+	Array.prototype.slice.call(document.querySelectorAll('code[data-source]')).forEach(function(codeContainer){
+		var xhr = new XMLHttpRequest();
+		xhr.open("GET", codeContainer.dataset.source, true);
+		xhr.overrideMimeType("text/plain; charset=x-user-defined");
+		xhr.onreadystatechange = function () {
+		    if (xhr.readyState == 4) {
+				if (xhr.status == 200) {
+					var code = document.createTextNode(xhr.responseText);
+					codeContainer.appendChild(code);
+					if(typeof(hljs) !== 'undefined')
+						hljs.highlightBlock(codeContainer);
+		        }
+		        else
+		        	console.error("Error while trying to get remote code");
+		    }
+		};
+		try {
+			xhr.send(null);
+		} catch (e) {
+			console.error("XHR failed for " + url + ", " + e);
+		}
+	});
+}


### PR DESCRIPTION
This would hopefully solve #7 .
I didn't want to commit the changes on the markdowns for the demo, to avoid messing with the content.

so now, in the markdown you can add :
```html
<pre><code data-source="/rust-handson/samples/helloworld/src/main.rs" data-trim class="hljs rust"></code></pre>
or
<pre><code data-source="../samples/helloworld/src/main.rs" data-trim class="hljs rust"></code></pre>
and for gist
<pre><code data-source="https://gist.githubusercontent.com/chikoski/5359389/raw/ada457391c2f4bbbb85e4fc5f375ab23a9cc67d2/hello_world.rs" data-trim class="hljs rust"></code></pre>
```

Let me know whether or not it fulfill the need.